### PR TITLE
Make backend dependencies explicit!

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -14,6 +14,8 @@
     "@aws-sdk/client-ses": "^3.998.0",
     "@msgpack/msgpack": "^3.1.3",
     "bytebuffer": "^5.0.1",
+    "express": "^4.16.4",
+    "mongodb": "^6.16.0",
     "protobufjs": "^6.9.0",
     "socket.io": "^4.8.3"
   },

--- a/node/package.json
+++ b/node/package.json
@@ -15,6 +15,7 @@
     "@msgpack/msgpack": "^3.1.3",
     "bytebuffer": "^5.0.1",
     "express": "^4.16.4",
+    "geoip-lite": "^1.4.10",
     "mongodb": "^6.16.0",
     "protobufjs": "^6.9.0",
     "socket.io": "^4.8.3"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"@aws-sdk/client-ses": "^3.998.0",
 		"@mongodb-js/zstd": "^2.0.1",
 		"argon2": "^0.44.0",
+		"body-parser": "^2.2.0",
 		"cookie-parser": "^1.4.5",
 		"express": "^4.16.4",
 		"geoip-lite": "^1.4.10",


### PR DESCRIPTION
When building distinct containers out of the app the backend uses some dependencies that it does not declare.
This PR makes the dependencies explicit and allows better container building!