### PR TITLE
Adds a Discord ↔ Adventure Land public-chat relay

### DIFF
--- a/adventure_functions.js
+++ b/adventure_functions.js
@@ -1186,6 +1186,24 @@ function server_url(server, api_method) {
 	return protocol + "://" + server.address + options.servers[server.key].api_path + api_method;
 }
 
+async function server_discord_chat(server, payload) {
+	if (!payload) payload = {};
+	try {
+		await fetch(server_url(server, "discord_chat"), {
+			method: "POST",
+			headers: { "Content-Type": "application/x-www-form-urlencoded" },
+			body: new URLSearchParams({
+				spass: keys.ACCESS_MASTER,
+				owner: payload.owner || "",
+				message: payload.message || "",
+				color: payload.color || "#5865F2",
+			}).toString(),
+		});
+	} catch (e) {
+		console.error("server_discord_chat error", e);
+	}
+}
+
 async function server_eval(server, code, data) {
 	if (!data) data = {};
 	try {

--- a/main.js
+++ b/main.js
@@ -684,6 +684,21 @@ app.all("/api", async (req, res, next) => {
 const PORT = process.env.PORT || options.port;
 app.listen(PORT, () => {
 	console.log(`\x1b[32mAdventure Land\x1b[0m listening on port ${PORT}`);
+	try {
+		const discord_inbound = require("./node/discord/inbound.js");
+		discord_inbound
+			.start_discord_inbound({
+				options: options,
+				keys: keys,
+				get_servers: get_servers,
+				server_discord_chat: server_discord_chat,
+			})
+			.catch(function (err) {
+				console.error("discord_inbound start failed", err);
+			});
+	} catch (e) {
+		console.error("discord_inbound load failed", e);
+	}
 });
 
 process.on("uncaughtException", function (err) {

--- a/node/discord/enqueue.js
+++ b/node/discord/enqueue.js
@@ -1,0 +1,148 @@
+/**
+ * Discord rate-limited sender for Adventure Land gameserver.
+ */
+
+function DiscordRateLimiter() {
+	this.channelQueues = new Map();
+	this.processing = new Set();
+	this.lastRequest = 0;
+	this.retryAfter = 0;
+	this.channelLimits = new Map();
+}
+
+DiscordRateLimiter.prototype.enqueue = function (message, callback) {
+	const channelId = message.channelId;
+	if (!this.channelQueues.has(channelId)) {
+		this.channelQueues.set(channelId, []);
+	}
+	this.channelQueues.get(channelId).push({ message: message, callback: callback });
+	this.processQueue(channelId);
+};
+
+DiscordRateLimiter.prototype.processQueue = async function (channelId) {
+	if (this.processing.has(channelId)) {
+		return;
+	}
+	this.processing.add(channelId);
+
+	try {
+		while (this.channelQueues.has(channelId) && this.channelQueues.get(channelId).length > 0) {
+			let now = Date.now();
+			if (this.retryAfter > now) {
+				await sleep(this.retryAfter - now);
+				now = Date.now();
+			}
+			const channelReset = this.channelLimits.get(channelId) || 0;
+			if (channelReset > now) {
+				await sleep(channelReset - now);
+				now = Date.now();
+			}
+			const sinceLast = now - this.lastRequest;
+			if (sinceLast < 20) {
+				await sleep(20 - sinceLast);
+				now = Date.now();
+			}
+
+			const item = this.channelQueues.get(channelId).shift();
+			if (!item) {
+				break;
+			}
+
+			try {
+				const response = await fetch(item.message.url, {
+					method: "POST",
+					headers: item.message.headers,
+					body: JSON.stringify(item.message.payload),
+				});
+				this.lastRequest = Date.now();
+
+				if (response.status === 429) {
+					const retryAfterHeader = response.headers.get("retry-after");
+					const retryMs = retryAfterHeader ? parseFloat(retryAfterHeader) * 1000 : 1000;
+					const isGlobal = response.headers.get("x-ratelimit-global");
+					if (isGlobal) {
+						this.retryAfter = Date.now() + retryMs;
+					} else {
+						this.channelLimits.set(channelId, Date.now() + retryMs);
+					}
+					this.channelQueues.get(channelId).unshift(item);
+					continue;
+				}
+
+				if (!response.ok) {
+					if (item.callback) {
+						item.callback(new Error("Discord API error: " + response.status));
+					}
+					continue;
+				}
+
+				const resetAfter = response.headers.get("x-ratelimit-reset-after");
+				const remaining = response.headers.get("x-ratelimit-remaining");
+				if (remaining === "0" && resetAfter) {
+					this.channelLimits.set(channelId, Date.now() + parseFloat(resetAfter) * 1000);
+				}
+				if (item.callback) {
+					item.callback(null, response);
+				}
+			} catch (err) {
+				if (item.callback) {
+					item.callback(err);
+				}
+			}
+		}
+	} finally {
+		this.processing.delete(channelId);
+		if (this.channelQueues.has(channelId) && this.channelQueues.get(channelId).length > 0) {
+			const self = this;
+			setImmediate(function () {
+				self.processQueue(channelId);
+			});
+		}
+	}
+};
+
+function sleep(ms) {
+	return new Promise(function (resolve) {
+		setTimeout(resolve, ms);
+	});
+}
+
+const rateLimiter = new DiscordRateLimiter();
+
+/**
+ * Queue a Discord bot message with per-channel rate limiting.
+ * @param {string} channelId
+ * @param {string} token
+ * @param {object} payload
+ * @param {function} [callback]
+ */
+function discord_enqueue(channelId, token, payload, callback) {
+	if (!channelId || !token) {
+		return;
+	}
+	if (!payload.allowed_mentions) {
+		payload.allowed_mentions = { parse: [] };
+	}
+	rateLimiter.enqueue(
+		{
+			channelId: channelId,
+			url: "https://discord.com/api/v10/channels/" + channelId + "/messages",
+			headers: {
+				Authorization: "Bot " + token,
+				"Content-Type": "application/json",
+			},
+			payload: payload,
+		},
+		callback ||
+			function (err) {
+				if (err) {
+					console.log("discord_call error", err);
+				}
+			},
+	);
+}
+
+module.exports = {
+	discord_enqueue: discord_enqueue,
+	DiscordRateLimiter: DiscordRateLimiter,
+};

--- a/node/discord/inbound.js
+++ b/node/discord/inbound.js
@@ -1,0 +1,141 @@
+/**
+ * Discord → game chat Gateway listener (main process only).
+ * Routes messages from per-server Discord channels to POST /discord_chat on that GS.
+ *
+ * Call start_discord_inbound(deps) from main.js after adventure_functions is eval'd.
+ * deps: { options, keys, get_servers, server_discord_chat }
+ */
+
+function build_channel_to_server_map(discord) {
+	const servers = (discord.channels && discord.channels.servers) || {};
+	const map = {};
+	const keys_list = Object.keys(servers);
+	for (let i = 0; i < keys_list.length; i++) {
+		const serverKey = keys_list[i];
+		const channelId = servers[serverKey];
+		if (!channelId) continue;
+		if (map[channelId]) {
+			console.error(
+				"discord_inbound: duplicate channelId " + channelId + " for " + map[channelId] + " and " + serverKey,
+			);
+			return null;
+		}
+		map[channelId] = serverKey;
+	}
+	return map;
+}
+
+function safe_discord_owner(displayName) {
+	// Avoid "Discord:name" — add_chat renders "owner: message", which looked like Discord:thmsn: …
+	return "[Discord] " + String(displayName || "user").replace(/[<>&"']/g, "");
+}
+
+function get_discord_token(keys) {
+	return (keys.discord && keys.discord.token) || keys.discord_token || "";
+}
+
+/**
+ * @param {{ options: object, keys: object, get_servers: Function, server_discord_chat: Function }} deps
+ */
+async function start_discord_inbound(deps) {
+	if (!deps || !deps.options || !deps.keys) {
+		console.error("discord_inbound: missing deps (options/keys)");
+		return;
+	}
+	const options = deps.options;
+	const keys = deps.keys;
+	const get_servers = deps.get_servers;
+	const server_discord_chat = deps.server_discord_chat;
+
+	const discord = options.discord || {};
+	if (!discord.enabled || !discord.inbound || !discord.inbound.enabled) {
+		return;
+	}
+	if (discord.chatMode && discord.chatMode !== "per_server") {
+		console.log("discord_inbound: inbound only runs for chatMode per_server");
+		return;
+	}
+	const token = get_discord_token(keys);
+	if (!token) {
+		console.log("discord_inbound: no discord token");
+		return;
+	}
+	const channelMap = build_channel_to_server_map(discord);
+	if (!channelMap || !Object.keys(channelMap).length) {
+		console.log("discord_inbound: no channels.servers mapped");
+		return;
+	}
+
+	let Discord;
+	try {
+		Discord = require("discord.js");
+	} catch (e) {
+		console.error("discord_inbound: install discord.js on the main process (npm i discord.js)");
+		return;
+	}
+
+	const client = new Discord.Client({
+		intents: [
+			Discord.GatewayIntentBits.Guilds,
+			Discord.GatewayIntentBits.GuildMessages,
+			Discord.GatewayIntentBits.MessageContent,
+		],
+	});
+
+	client.once("ready", function () {
+		console.log("discord_inbound: logged in as " + client.user.tag);
+	});
+
+	client.on("messageCreate", async function (message) {
+		try {
+			if (!message || !message.channelId) return;
+			if (message.author && message.author.bot) return;
+			if (message.webhookId) return;
+			if (client.user && message.author && message.author.id === client.user.id) return;
+
+			const serverKey = channelMap[message.channelId];
+			if (!serverKey) return;
+
+			let content = (message.content || "").trim();
+			if (!content) return;
+			if (content.length > 1200) content = content.substr(0, 1200);
+
+			const servers = await get_servers();
+			let target = null;
+			for (let i = 0; i < servers.length; i++) {
+				if (servers[i].key === serverKey) {
+					target = servers[i];
+					break;
+				}
+			}
+			if (!target) {
+				console.log("discord_inbound: no online server for key " + serverKey);
+				return;
+			}
+
+			const display =
+				(message.member && message.member.displayName) ||
+				(message.author && (message.author.globalName || message.author.username)) ||
+				"user";
+
+			await server_discord_chat(target, {
+				owner: safe_discord_owner(display),
+				message: content,
+				color: "#5865F2",
+			});
+		} catch (err) {
+			console.error("discord_inbound messageCreate error", err);
+		}
+	});
+
+	client.on("error", function (err) {
+		console.error("discord_inbound client error", err);
+	});
+
+	await client.login(token);
+}
+
+module.exports = {
+	start_discord_inbound: start_discord_inbound,
+	build_channel_to_server_map: build_channel_to_server_map,
+};

--- a/node/discord/index.js
+++ b/node/discord/index.js
@@ -1,0 +1,21 @@
+/**
+ * Discord integration for Adventure Land (gameserver outbound + main inbound).
+ *
+ *   require("./discord")           — enqueue + outbound helpers
+ *   require("./discord/inbound")   — Gateway listener (main only)
+ */
+
+const enqueue = require("./enqueue.js");
+const outbound = require("./outbound.js");
+
+module.exports = {
+	discord_enqueue: enqueue.discord_enqueue,
+	DiscordRateLimiter: enqueue.DiscordRateLimiter,
+	DISCORD_CLASS_EMOJIS: outbound.DISCORD_CLASS_EMOJIS,
+	discord_token: outbound.discord_token,
+	discord_should_post: outbound.discord_should_post,
+	discord_event_channel_id: outbound.discord_event_channel_id,
+	discord_public_chat_channel_id: outbound.discord_public_chat_channel_id,
+	discord_call: outbound.discord_call,
+	discord_public_chat: outbound.discord_public_chat,
+};

--- a/node/discord/outbound.js
+++ b/node/discord/outbound.js
@@ -1,0 +1,110 @@
+/**
+ * Gameserver → Discord outbound helpers (events + public chat).
+ * Call with a GS ctx so this module does not depend on eval globals.
+ *
+ * ctx: { options, keys, gameplay, Dev, server_key, region, server_name, server_log }
+ */
+
+const enqueue = require("./enqueue.js");
+
+const DISCORD_CLASS_EMOJIS = {
+	warrior: "🛡️",
+	mage: "🔮",
+	priest: "✨",
+	rogue: "🗡️",
+	ranger: "🏹",
+	paladin: "⚔️",
+	merchant: "💰",
+};
+
+function discord_token(ctx) {
+	const keys = ctx.keys;
+	return (keys.discord && keys.discord.token) || keys.discord_token || "";
+}
+
+function discord_should_post(ctx) {
+	if (ctx.gameplay == "hardcore" || ctx.gameplay == "test") {
+		return false;
+	}
+	const discord_opts = ctx.options.discord || {};
+	if (discord_opts.enabled === false) {
+		return false;
+	}
+	// Explicit enabled:true allows local Dev testing; otherwise Dev only logs.
+	if (ctx.Dev && discord_opts.enabled !== true) {
+		return false;
+	}
+	return !!discord_token(ctx);
+}
+
+function discord_event_channel_id(message, ctx) {
+	const channels = (ctx.options.discord && ctx.options.discord.channels) || {};
+	const default_channel =
+		channels.default === undefined || channels.default === null ? "404333059018719233" : channels.default;
+	const join_channel = channels.join === undefined || channels.join === null ? "839163123499794481" : channels.join;
+	if (message && message.search(" joined Adventure Land") != -1) {
+		return join_channel;
+	}
+	return default_channel;
+}
+
+function discord_public_chat_channel_id(ctx) {
+	const discord_opts = ctx.options.discord || {};
+	const channels = discord_opts.channels || {};
+	if (discord_opts.chatMode === "shared") {
+		return channels.publicChat || "";
+	}
+	const servers = channels.servers || {};
+	return servers[ctx.server_key] || "";
+}
+
+function discord_call(message, ctx) {
+	if (!discord_should_post(ctx)) {
+		if (ctx.Dev) {
+			return ctx.server_log("Discord: " + message);
+		}
+		return;
+	}
+	const channel_id = discord_event_channel_id(message, ctx);
+	if (!channel_id) {
+		return;
+	}
+	enqueue.discord_enqueue(channel_id, discord_token(ctx), { content: message });
+}
+
+function discord_public_chat(player, message, ctx) {
+	if (!discord_should_post(ctx)) {
+		return;
+	}
+	const channel_id = discord_public_chat_channel_id(ctx);
+	if (!channel_id) {
+		return;
+	}
+	const discord_opts = ctx.options.discord || {};
+	const classEmoji = DISCORD_CLASS_EMOJIS[player.ctype || player.type] || "";
+	let prefix = "";
+	// Per-server channels already imply the GS; only tag the server in shared mode.
+	if (discord_opts.chatMode === "shared") {
+		prefix = "[" + ctx.region + "-" + ctx.server_name + "] ";
+	}
+	const content =
+		prefix +
+		(classEmoji ? classEmoji + " " : "") +
+		"**" +
+		player.name +
+		"** (" +
+		player.level +
+		"): " +
+		message;
+	enqueue.discord_enqueue(channel_id, discord_token(ctx), { content: content });
+}
+
+module.exports = {
+	DISCORD_CLASS_EMOJIS: DISCORD_CLASS_EMOJIS,
+	discord_token: discord_token,
+	discord_should_post: discord_should_post,
+	discord_event_channel_id: discord_event_channel_id,
+	discord_public_chat_channel_id: discord_public_chat_channel_id,
+	discord_call: discord_call,
+	discord_public_chat: discord_public_chat,
+};

--- a/node/server.js
+++ b/node/server.js
@@ -716,6 +716,23 @@ server_api.post("/eval", (req, res) => {
 	res.send(JSON.stringify(output));
 });
 
+
+server_api.post("/discord_chat", (req, res) => {
+	if (req.body.spass !== keys.ACCESS_MASTER) return res.status(403).send("");
+	const message = strip_string(req.body.message || "").substr(0, 1200);
+	const owner = strip_string(req.body.owner || "").substr(0, 80);
+	if (!message || !owner) {
+		return res.status(400).send("bad");
+	}
+	broadcast("chat_log", {
+		owner: owner,
+		message: message,
+		p: true,
+		color: req.body.color || "#5865F2",
+	});
+	res.send("yes");
+});
+
 app.use(server_def.api_path, server_api);
 
 function player_to_server(player, place) {
@@ -4665,6 +4682,7 @@ function init_socket_io(socket_server) {
 			} else {
 				if (1) {
 					broadcast("chat_log", { owner: player.name, message: message, id: player.id, p: true });
+					discord_public_chat(player, message);
 					var owners = {};
 					for (var id in players) {
 						var p = players[id];

--- a/node/server_functions.js
+++ b/node/server_functions.js
@@ -3285,24 +3285,26 @@ function xy_upush_logic(element) {
 
 // appengine_call removed - all calls replaced with direct MongoDB operations
 
+/** GS eval-scope ctx for node/discord outbound helpers. */
+function discord_gs_ctx() {
+	return {
+		options: options,
+		keys: keys,
+		gameplay: gameplay,
+		Dev: Dev,
+		server_key: server_key,
+		region: region,
+		server_name: server_name,
+		server_log: server_log,
+	};
+}
+
 function discord_call(message) {
-	if (gameplay == "hardcore" || gameplay == "test") {
-		return;
-	}
-	if (Dev) {
-		return server_log("Discord: " + message);
-	}
-	var url = "https://discordapp.com/api/channels/404333059018719233/messages";
-	if (message.search(" joined Adventure Land") != -1) {
-		url = "https://discordapp.com/api/channels/839163123499794481/messages";
-	}
-	fetch(url, {
-		method: "POST",
-		headers: { Authorization: "Bot " + keys.discord_token, "Content-Type": "application/json" },
-		body: JSON.stringify({ content: message }),
-	}).catch(function (err) {
-		console.log("discord_call error", err);
-	});
+	return require("./discord").discord_call(message, discord_gs_ctx());
+}
+
+function discord_public_chat(player, message) {
+	return require("./discord").discord_public_chat(player, message, discord_gs_ctx());
 }
 
 function server_log(message, important) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 		"@mongodb-js/zstd": "^2.0.1",
 		"argon2": "^0.44.0",
 		"cookie-parser": "^1.4.5",
+		"discord.js": "^14.27.0",
 		"express": "^4.16.4",
 		"geoip-lite": "^1.4.10",
 		"mongodb": "^6.16.0",


### PR DESCRIPTION
## Summary
Adds a Discord ↔ Adventure Land public-chat relay:

- **Game → Discord:** public `say` posts via rate-limited Bot REST (`node/discord/`).
- **Discord → Game:** main runs a Gateway listener and `POST`s to that gameserver’s `/discord_chat` (spass), not `server_eval`.
- Event posts (`discord_call`: joins, shutdowns, etc.) use configurable event channels.
<img width="213" height="74" alt="image" src="https://github.com/user-attachments/assets/0f7a963f-8de6-499d-bc17-b1bfce4d935e" />
<img width="284" height="125" alt="image" src="https://github.com/user-attachments/assets/717c1099-0560-40dc-801d-833c7f90f150" />


## Creating the Discord bot
1. [Discord Developer Portal](https://discord.com/developers/applications) → **New Application**.
2. **Bot** → Add Bot → **Reset Token** / copy token.
3. Enable **Message Content Intent** (required for Discord → game) → Save.  
   Docs: [Getting Started](https://discord.com/developers/docs/quick-start/getting-started) · [Privileged Intents](https://discord.com/developers/docs/topics/gateway#privileged-intents).
4. **OAuth2 → URL Generator:** scope `bot`; permissions **View Channel**, **Send Messages**, **Read Message History** (add more if you want).
5. Open the invite URL, pick the guild, confirm.
6. Discord client → Settings → Advanced → **Developer Mode** → right-click each channel → **Copy Channel ID**.

Install dependency on the main process host: `npm i` (adds `discord.js`).

---

## Config (copy/paste into secretsandconfig)

```js
// keys.js
discord_token: "YOUR_BOT_TOKEN", // or keys.discord.token

// options.js
discord: {
  enabled: true,           // false = fully off
                           // Dev: posts only if enabled === true (otherwise logs)
  chatMode: "per_server",  // "per_server" | "shared"

  channels: {
    // Event posts (join / misc). Prefer explicit IDs.
    // If left undefined/null, code still falls back to legacy hardcodes
    // set "" to disable a channel.
    default: "404333059018719233",
    join: "839163123499794481",

    // Shared mode only (ignored when chatMode is per_server):
    // publicChat: "ONE_SHARED_CHANNEL_ID",

    // Per-server chat: options.servers KEY → Discord channel snowflake.
    // Create one Discord channel per realm you want linked.
    // Rename each key to match your live Object.keys(options.servers).
    servers: {
      // --- official UI labels (region + " " + name) — keys are NOT these strings ---
      // EU I:
      YOUR_EU_I_KEY: "DISCORD_CHANNEL_ID",
      // EU II:
      YOUR_EU_II_KEY: "DISCORD_CHANNEL_ID",
      // EU PVP:
      YOUR_EU_PVP_KEY: "DISCORD_CHANNEL_ID",
      // ASIA I:
      YOUR_ASIA_I_KEY: "DISCORD_CHANNEL_ID",
      // US I:
      YOUR_US_I_KEY: "DISCORD_CHANNEL_ID",
      // US II:
      YOUR_US_II_KEY: "DISCORD_CHANNEL_ID",
      // US III:
      YOUR_US_III_KEY: "DISCORD_CHANNEL_ID",
      // US PVP:
      YOUR_US_PVP_KEY: "DISCORD_CHANNEL_ID",

      // Local / staging examples (typical docker key is "local"):
      // local: "DISCORD_CHANNEL_ID",
    },
  },

  inbound: {
    enabled: true, // Gateway on main; only with chatMode per_server
  },
},
```
### 4) Restart
Restart **main** (inbound + config load) and each **gameserver** (outbound uses `server_key` + channel map).

### 5) Smoke test
- In-game public say → appears in the mapped Discord channel (`per_server`: no `[region-name]` prefix; `shared`: includes `[region-name]`).
- (Bidirectional only) Discord message in that channel → in-game as `[Discord] DisplayName: …`.

---

## Hardcoded channel fallbacks (intentional for now — prefer options)

Official `main` historically hardcoded two channel IDs inside `discord_call`. This PR still **falls back** to those same IDs when `options.discord.channels.default` / `.join` are `undefined` / `null`:

| Use | Hardcoded fallback in `node/discord/outbound.js` |
|-----|--------------------------------------------------|
| Default events | `404333059018719233` |
| Join events (`" joined Adventure Land"`) | `839163123499794481` |

**Recommendation for operators / follow-up:** set `channels.default` and `channels.join` explicitly in `options.js` (empty string `""` disables that channel). A later cleanup should remove the hardcoded fallbacks so channel IDs live only in options—keeping official channel IDs out of server source.

Public chat has **no** hardcoded channel: if `channels.servers[server_key]` (or `publicChat` in shared mode) is missing/empty, outbound public chat is a no-op.

---

## Behaviour notes
- Mentions are suppressed on outbound posts (`allowed_mentions: { parse: [] }`).
- Hardcore / test gameplay skips Discord posts.
- Inbound ignores bots/webhooks and the bot’s own messages.
- Message length capped at 1200 characters.
