### PR TITLE
Name missing items when enter is blocked

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -2038,7 +2038,17 @@ function init_socket(args) {
 				ui_log("Instance not found", "gray");
 				transporting = false;
 			} else if (response == "transport_cant_item") {
-				ui_log("Item not found", "gray");
+				var missing = data.items;
+				var parts = [];
+				if (missing) {
+					for (var iname in missing) {
+						if (!Object.prototype.hasOwnProperty.call(missing, iname)) continue;
+						var qty = missing[iname];
+						var label = (G.items[iname] && G.items[iname].name) || iname;
+						parts.push(qty + "× " + label);
+					}
+				}
+				ui_log(parts.length ? "Need " + parts.join(", ") : "Item not found", "gray");
 				transporting = false;
 			} else if (response == "transport_cant_dampened") {
 				ui_log("Can't transport inside a dampening field", "#A772D0");


### PR DESCRIPTION
## Summary
- Show which key items are missing when enter fails (`transport_cant_item`) instead of a vague FFT.
- Makes bee dungeon playtesting clearer and keeps future gated-map UX reviewable in a small PR.

## Test plan
- [ ] Attempt enter without required items; message names what is missing
- [ ] Enter with all required items still works
- [ ] No change when other enter failures apply


Made with [Cursor](https://cursor.com)