### PR TITLE
Run server_bfs for instance maps with NPCs/monsters

### DIFF
--- a/node/server.js
+++ b/node/server.js
@@ -517,12 +517,18 @@ async function init_game() {
 			create_instance("ucliffs");
 			create_instance("uhills");
 			create_instance("mforest");
-			server_bfs("crypt");
-			server_bfs("winter_instance");
-			server_bfs("spider_instance");
-			server_bfs("tomb");
-			server_bfs("dungeon0");
-			server_bfs("cgallery");
+			for (const name in G.maps) {
+				const gMap = G.maps[name];
+				if (gMap.ignore) {
+					continue;
+				}
+				const hasNpcs = gMap.npcs && gMap.npcs.length > 0;
+				const hasMonsters = gMap.monsters && gMap.monsters.length > 0;
+				if (gMap.instance && (hasNpcs || hasMonsters)) {
+					// running this is important for instances, so that npcs and monsters can navigate / move
+					server_bfs(name);
+				}
+			}
 		} else if (gameplay == "dungeon") {
 			for (var name in G.maps) {
 				if (G.maps[name].world == "dungeon") {


### PR DESCRIPTION
## Summary
- Run `server_bfs` for all instance maps that have NPCs or monsters, instead of a hardcoded map list.
- Lets new bee dungeon instances get pathing/AI without special-casing, and keeps that plumbing out of the dungeon PR.

## Test plan
- [ ] Boot a server with an instance map that has NPCs/monsters; confirm BFS runs for it
- [ ] Existing non-instance maps unchanged
- [ ] Instance without NPCs/monsters still skipped as expected


Made with [Cursor](https://cursor.com)