### PR TITLE
Map editor JSON import + design/maps fallback

### DIFF
--- a/adventure_functions.js
+++ b/adventure_functions.js
@@ -1653,3 +1653,41 @@ function process_map(map) {
 	data.max_x = max_x;
 	data.max_y = max_y;
 }
+
+/**
+ * Load map geometry from Mongo (MP_<key>), or import from design/maps/<key>.json
+ * when the document is missing (enables shipping new maps as JSON files).
+ * Works when eval'd from repo root (main.js) or node/ (server.js).
+ */
+async function load_map_geometry_or_import(key) {
+	var map = await get("MP_" + key);
+	if (map && map.info && map.info.data) {
+		return map.info.data;
+	}
+	var candidates = [path.resolve(__dirname, "design/maps", key + ".json"), path.resolve(__dirname, "../design/maps", key + ".json")];
+	var filename = null;
+	for (var i = 0; i < candidates.length; i++) {
+		if (fs.existsSync(candidates[i])) {
+			filename = candidates[i];
+			break;
+		}
+	}
+	if (!filename) {
+		return null;
+	}
+	console.warn("MP_" + key + " not found. Importing from " + filename);
+	var data = JSON.parse(fs.readFileSync(filename, "utf8"));
+	map = {
+		_id: "MP_" + key,
+		name: key,
+		created: new Date(),
+		updated: new Date(),
+		info: { data: data },
+		blobs: ["info"],
+	};
+	process_map(map);
+	map.updated = new Date();
+	await save(map);
+	return map.info.data;
+}
+

--- a/api.js
+++ b/api.js
@@ -54,8 +54,8 @@ async function load_geometry() {
 	for (var name in maps) {
 		var key = maps[name].key;
 		if (maps[name].ignore) continue;
-		var map = await get("MP_" + key);
-		if (map) geometry[name] = map.info.data;
+		var data = await load_map_geometry_or_import(key);
+		if (data) geometry[name] = data;
 	}
 	return geometry;
 }

--- a/main.js
+++ b/main.js
@@ -299,12 +299,12 @@ app.all("/data.js", async (req, res, next) => {
 		rpc = {};
 	for (var id in maps) {
 		if (maps[id].ignore) continue;
-		rpc[id] = get("MP_" + maps[id].key);
+		rpc[id] = load_map_geometry_or_import(maps[id].key);
 	}
 	for (var id in maps) {
 		if (maps[id].ignore) continue;
-		var map = await rpc[id];
-		if (map) geometry[id] = map.info.data;
+		var mapData = await rpc[id];
+		if (mapData) geometry[id] = mapData;
 	}
 	var G = {
 		version: Version,

--- a/node/server.js
+++ b/node/server.js
@@ -406,12 +406,12 @@ async function init_game() {
 		for (var id in maps) {
 			if (maps[id].ignore) continue;
 			var key = maps[id].key;
-			rpc[id] = get("MP_" + key);
+			rpc[id] = load_map_geometry_or_import(key);
 		}
 		for (var id in maps) {
 			if (maps[id].ignore) continue;
-			var map = await rpc[id];
-			if (map) geometry[id] = map.info.data;
+			var mapData = await rpc[id];
+			if (mapData) geometry[id] = mapData;
 		}
 
 		// Build G (game data) from design globals (matches create_server_api output)
@@ -588,12 +588,12 @@ async function reload_server(to_broadcast, change) {
 		var rpc = {};
 		for (var id in maps) {
 			if (maps[id].ignore) continue;
-			rpc[id] = get("MP_" + maps[id].key);
+			rpc[id] = load_map_geometry_or_import(maps[id].key);
 		}
 		for (var id in maps) {
 			if (maps[id].ignore) continue;
-			var map = await rpc[id];
-			if (map) geometry[id] = map.info.data;
+			var mapData = await rpc[id];
+			if (mapData) geometry[id] = mapData;
 		}
 
 		G = {

--- a/utility/htmls/map_editor.html
+++ b/utility/htmls/map_editor.html
@@ -179,9 +179,10 @@
 			<div class="gamebutton clickable linesbutton mt5" onclick="toggle_lines();">Info: ON</div>
 			<div class="gamebutton clickable alertbutton mbutton largerfont mt5" onclick="toggle_alert_mode();">
 				<div class="px2"></div>
-				±
+				Â±
 			</div>
 			<div class="gamebutton clickable mt5" onclick="show_json(map_data);">JSON</div>
+			<div class="gamebutton clickable mt5" onclick="show_import_map();">IMPORT</div>
 			{% if resort %}
 			<div class="gamebutton clickable mt5" onclick="show_upload_modal();">UPLOAD</div>
 			{% endif %}

--- a/utility/htmls/map_editor.js
+++ b/utility/htmls/map_editor.js
@@ -1015,6 +1015,48 @@ function show_upload_modal()
 	$('#toprightcorner').show();
 }
 
+function show_import_map() {
+	function onImportMapJsonChange(event) {
+		var reader = new FileReader();
+		reader.onload = onReaderLoad;
+		reader.readAsText(event.target.files[0]);
+	}
+
+	function onReaderLoad(event) {
+		$("#import_map_json").val(event.target.result);
+	}
+
+	function import_map() {
+		const text = $("#import_map_json").val();
+		const json = JSON.parse(text);
+		for (const key in json) {
+			const value = json[key];
+			map_data[key] = value;
+		}
+
+		$("#toprightcorner").hide();
+		$("#toprightcorner").html("");
+
+		redraw_map();
+	}
+
+	var html = "<div style='font-size: 32px;'>";
+	html +=
+		"<div style='margin-bottom: 20px'>The following will replace all data in your currently loaded map, press save to persist it</div>";
+	html += `
+	<input id="import_map_file" type="file" accept=".json" /><br/>
+	<textarea id="import_map_json" rows="10" style="min-height:600px; min-width:600px"></textarea>
+	<button id="import_map_button" style="margin-bottom:20px;">Import</button>
+	<br/>
+	<br/>
+	`;
+	html += "</div>";
+	$("#toprightcorner").html(html);
+	$("#toprightcorner").show();
+	$("#import_map_file").on("change", onImportMapJsonChange);
+	$("#import_map_button").on("click", import_map);
+}
+
 function rescale_map(nscale)
 {
 	var ox=(map.x-round(width/2))/scale,oy=(map.y-round(height/2))/scale;
@@ -1069,20 +1111,21 @@ function redraw_map()
 
 	to_delete=[]; deleted=false;
 
-	for(var i=0;i<map_data.placements.length;i++)
-	{
-		var tile=map_data.placements[i];
-		try{
-			if(!is_nun(tile[3])) place_area(tile[0],tile[1],tile[2],tile[3],tile[4],"yes");
-			else place_tile(tile[0],tile[1],tile[2],"yes");
-		}catch(e)
+	if (map_data.placements) {
+		for(var i=0;i<map_data.placements.length;i++)
 		{
-			console.log("Faulty tile detected + deleted"); deleted=true;
-			to_delete.push(i);
+			var tile=map_data.placements[i];
+			try{
+				if(!is_nun(tile[3])) place_area(tile[0],tile[1],tile[2],tile[3],tile[4],"yes");
+				else place_tile(tile[0],tile[1],tile[2],"yes");
+			}catch(e)
+			{
+				console.log("Faulty tile detected + deleted"); deleted=true;
+				to_delete.push(i);
+			}
 		}
+		delete_indices(map_data.placements,to_delete);
 	}
-	
-	delete_indices(map_data.placements,to_delete);
 	if(deleted) show_alert("Deleted some faulty tiles, this might have happened if you shrinked your own tileset, or if you increased your tile area after selecting a tile etc.");
 
 	to_delete=[]; deleted=false;


### PR DESCRIPTION
## Summary
- Add map editor JSON import and a design/maps fallback so dungeon maps can be authored and iterated without hand-wiring.
- Shrinks bee dungeon review surface and makes future map work easier to land separately.

## Test plan
- [ ] Import a map JSON in the map editor and verify it loads
- [ ] Confirm design/maps fallback resolves when expected
- [ ] Existing edit/save flow still works for a known map


Made with [Cursor](https://cursor.com)